### PR TITLE
Update advancedLua.lua

### DIFF
--- a/lib/advancedLua.lua
+++ b/lib/advancedLua.lua
@@ -85,7 +85,7 @@ end
 
 function math.roundToDecimalPlaces(num, decimalPlaces)
 	local mult = 10 ^ (decimalPlaces or 0)
-	return math.floor(num * mult + 0.5) / mult
+	return math.round(num * mult) / mult
 end
 
 function math.getDigitCount(num)


### PR DESCRIPTION
Теперь roundToDecimalPlaces() правильнее округляет отрицательные числа.
Вот только не говори, Игорь, что round() тут низя использовать, а то это уже свинство будет.